### PR TITLE
fixup! miku: Switch Gapps to another repo

### DIFF
--- a/snippets/miku.xml
+++ b/snippets/miku.xml
@@ -176,6 +176,6 @@
   <project path="packages/overlays/Themes" name="platform_packages_overlays_Themes" remote="miku" revision="TDA" />
 	
   <!-- GAPPS -->
-  <project path="vendor/gapps" name="vendor_gapps" remote="mind" >
+  <project path="vendor/gapps" name="vendor_gapps" remote="mind" />
 
 </manifest>


### PR DESCRIPTION
error: in `sync -j6 --force-sync`: error parsing manifest /home/anrui/android/miku/.repo/manifests/snippets/miku.xml: no element found: line 182, column 0