### PR TITLE
miku: switch default revision of lineage snippet to lineage-23.2

### DIFF
--- a/snippets/lineage.xml
+++ b/snippets/lineage.xml
@@ -3,7 +3,7 @@
 
   <remote name="lineage"
           fetch="https://github.com/LineageOS"
-          revision="lineage-22.2" />
+          revision="lineage-23.2" />
 
   <!-- External -->
   <project path="external/json-c" name="android_external_json-c" remote="lineage" />


### PR DESCRIPTION
This requires some commits from Lineage's prebuilts_misc and kernel_configs to be cherry-picked/merged in order to function correctly.